### PR TITLE
Prevent new instance attributes from being filled and instigating mutators

### DIFF
--- a/src/HasChildren.php
+++ b/src/HasChildren.php
@@ -68,9 +68,14 @@ trait HasChildren
     {
         $attributes = (array) $attributes;
 
+        $inheritanceAttributes = [];
         $inheritanceColumn = $this->getInheritanceColumn();
 
-        $model = $this->newInstance([$inheritanceColumn => $attributes[$inheritanceColumn]], true);
+        if (isset($attributes[$inheritanceColumn])) {
+            $inheritanceAttributes[$inheritanceColumn] = $attributes[$inheritanceColumn];
+        }
+
+        $model = $this->newInstance($inheritanceAttributes, true);
 
         $model->setRawAttributes($attributes, true);
 

--- a/src/HasChildren.php
+++ b/src/HasChildren.php
@@ -66,9 +66,13 @@ trait HasChildren
 
     public function newFromBuilder($attributes = [], $connection = null)
     {
-        $model = $this->newInstance((array) $attributes, true);
+        $attributes = (array) $attributes;
 
-        $model->setRawAttributes((array) $attributes, true);
+        $inheritanceColumn = $this->getInheritanceColumn();
+
+        $model = $this->newInstance([$inheritanceColumn => $attributes[$inheritanceColumn]], true);
+
+        $model->setRawAttributes($attributes, true);
 
         $model->setConnection($connection ?: $this->getConnectionName());
 

--- a/tests/Unit/HasChildrenTest.php
+++ b/tests/Unit/HasChildrenTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Parental\Tests\Unit;
+
+use Illuminate\Database\Eloquent\Model;
+use Parental\HasChildren;
+use Parental\Tests\TestCase;
+
+class HasChildrenTest extends TestCase
+{
+    /** @test */
+    function child_model_mutators_are_not_instigated()
+    {
+        $model = (new HasChildrenParentModel)->newFromBuilder([
+            'type' => HasChildrenChildModel::class,
+            'test' => 'value'
+        ]);
+
+        $this->assertEquals($model->mutatorWasCalled, false);
+    }
+}
+
+class HasChildrenParentModel extends Model {
+    use HasChildren;
+
+    protected $fillable = ['type', 'test'];
+}
+
+class HasChildrenChildModel extends HasChildrenParentModel {
+    public $mutatorWasCalled = false;
+
+    public function setTestAttribute()
+    {
+        $this->mutatorWasCalled = true;
+    }
+}


### PR DESCRIPTION
The problem: as the first step in `newFromBuilder`, `newInstance` is
being called with all of the model's attributes. `newInstance` then
passes the attributes into the Model constructor (via `getChildModel`).
The Model constructor then passes the attributes into `fill`. This means
that attribute mutators are called on model initialization, which is NOT
desirable.

Compare this to Eloquent's default `newFromBuilder` method, which passes
an empty array into `newInstance`. The model is initialized without
attributes, and then `setRawAttributes` is called to set the attributes
without instigating the attribute mutators.

Of course, it's important for `newInstance` to have the value of the
inheritance column attribute so that it can work out what class to
instantiate. This commit adjusts the `newFromBuilder` method so that
this is the only attribute passed into `newInstance`; the rest are then
set via `setRawAttributes`.