### PR TITLE
Added comment blocks to methods

### DIFF
--- a/src/HasChildren.php
+++ b/src/HasChildren.php
@@ -49,6 +49,11 @@ trait HasChildren
         return false;
     }
 
+    /**
+     * @param array $attributes
+     * @param bool $exists
+     * @return $this
+     */
     public function newInstance($attributes = [], $exists = false)
     {
         $model = isset($attributes[$this->getInheritanceColumn()])
@@ -64,6 +69,11 @@ trait HasChildren
         return $model;
     }
 
+    /**
+     * @param array $attributes
+     * @param null $connection
+     * @return $this
+     */
     public function newFromBuilder($attributes = [], $connection = null)
     {
         $model = $this->newInstance((array) $attributes, true);
@@ -77,6 +87,15 @@ trait HasChildren
         return $model;
     }
 
+    /**
+     * Define an inverse one-to-one or many relationship.
+     *
+     * @param  string  $related
+     * @param  string  $foreignKey
+     * @param  string  $ownerKey
+     * @param  string  $relation
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
     public function belongsTo($related, $foreignKey = null, $ownerKey = null, $relation = null)
     {
         $instance = $this->newRelatedInstance($related);
@@ -92,11 +111,31 @@ trait HasChildren
         return parent::belongsTo($related, $foreignKey, $ownerKey, $relation);
     }
 
+    /**
+     * Define a one-to-many relationship.
+     *
+     * @param  string  $related
+     * @param  string  $foreignKey
+     * @param  string  $localKey
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
     public function hasMany($related, $foreignKey = null, $localKey = null)
     {
         return parent::hasMany($related, $foreignKey, $localKey);
     }
 
+    /**
+     * Define a many-to-many relationship.
+     *
+     * @param  string  $related
+     * @param  string  $table
+     * @param  string  $foreignPivotKey
+     * @param  string  $relatedPivotKey
+     * @param  string  $parentKey
+     * @param  string  $relatedKey
+     * @param  string  $relation
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     */
     public function belongsToMany($related, $table = null, $foreignPivotKey = null, $relatedPivotKey = null, $parentKey = null, $relatedKey = null, $relation = null)
     {
         $instance = $this->newRelatedInstance($related);
@@ -108,16 +147,26 @@ trait HasChildren
         return parent::belongsToMany($related, $table, $foreignPivotKey, $relatedPivotKey, $parentKey, $relatedKey, $relation);
     }
 
+    /**
+     * @return string
+     */
     public function getClassNameForRelationships()
     {
         return class_basename($this);
     }
 
+    /**
+     * @return string
+     */
     public function getInheritanceColumn()
     {
         return property_exists($this, 'childColumn') ? $this->childColumn : 'type';
     }
 
+    /**
+     * @param array $attributes
+     * @return mixed
+     */
     protected function getChildModel(array $attributes)
     {
         $className = $this->classFromAlias(
@@ -127,6 +176,10 @@ trait HasChildren
         return new $className((array)$attributes);
     }
 
+    /**
+     * @param $aliasOrClass
+     * @return string
+     */
     public function classFromAlias($aliasOrClass)
     {
         if (property_exists($this, 'childTypes')) {
@@ -138,6 +191,10 @@ trait HasChildren
         return $aliasOrClass;
     }
 
+    /**
+     * @param $className
+     * @return string
+     */
     public function classToAlias($className)
     {
         if (property_exists($this, 'childTypes')) {
@@ -149,6 +206,9 @@ trait HasChildren
         return $className;
     }
 
+    /**
+     * @return array
+     */
     public function getChildTypes()
     {
         return property_exists($this, 'childTypes') ? $this->childTypes : [];

--- a/src/HasParent.php
+++ b/src/HasParent.php
@@ -28,11 +28,18 @@ trait HasParent
         });
     }
 
+    /**
+     * @return bool
+     */
     public function parentHasHasChildrenTrait()
     {
         return $this->hasChildren ?? false;
     }
 
+    /**
+     * @return string
+     * @throws \ReflectionException
+     */
     public function getTable()
     {
         if (! isset($this->table)) {
@@ -42,11 +49,21 @@ trait HasParent
         return $this->table;
     }
 
+    /**
+     * @return string
+     * @throws \ReflectionException
+     */
     public function getForeignKey()
     {
         return Str::snake(class_basename($this->getParentClass())).'_'.$this->primaryKey;
     }
 
+    /**
+     * @param $related
+     * @param null $instance
+     * @return string
+     * @throws \ReflectionException
+     */
     public function joiningTable($related, $instance = null)
     {
         $relatedClassName = method_exists((new $related), 'getClassNameForRelationships')
@@ -63,11 +80,21 @@ trait HasParent
         return strtolower(implode('_', $models));
     }
 
+    /**
+     * @return string
+     * @throws \ReflectionException
+     */
     public function getClassNameForRelationships()
     {
         return class_basename($this->getParentClass());
     }
 
+    /**
+     * Get the class name for polymorphic relations.
+     *
+     * @return string
+     * @throws \ReflectionException
+     */
     public function getMorphClass()
     {
         if ($this->parentHasHasChildrenTrait()) {
@@ -78,6 +105,12 @@ trait HasParent
         return parent::getMorphClass();
     }
 
+    /**
+     * Get the class name for Parent Class.
+     *
+     * @return string
+     * @throws \ReflectionException
+     */
     protected function getParentClass()
     {
         static $parentClassName;


### PR DESCRIPTION
Added comment blocks to type-hint eloquent relationships implemented by models using this package.

The default behaviour when using eloquent relations is it will inherit comment blocks from Laravel trait HasRelations, 
However, when using this package traits those comments are overridden by methods implemented in the package.