### PR TITLE
Better resolution of polymorphic relations for sub models in STI

### DIFF
--- a/src/HasParent.php
+++ b/src/HasParent.php
@@ -103,12 +103,9 @@ trait HasParent
      */
     public function getMorphClass()
     {
-        if ($this->parentHasHasChildrenTrait()) {
-            $parentClass = $this->getParentClass();
-            return (new $parentClass)->getMorphClass();
-        }
-
-        return parent::getMorphClass();
+        $parentClass = $this->getParentClass();
+        
+        return (new $parentClass)->getMorphClass();
     }
 
     /**


### PR DESCRIPTION
Hi Caleb,

I'm convinced the `getMorphClass()` of the HasParent trait should always return `($this->getParentClass())->getMorphClass();` value instead of `parent::getMorphClass()`. Not just when the parent class use `HasChildren` trait for the following reasons:

Let's say you have 2 model classes. Article and PublishedArticle

PublishedArticle is the subclass of article. Rather than relying on the type column. PublishedArticle is an article whose published_at value is <= Carbon::now();

```php
    public static function boot()
    {
        parent::boot();

        static::addGlobalScope(function (Builder $builder) {
            $builder->where('published_at', '<=', Carbon::now());
        });
    }
```

However, because articles table has no type column and Article model didn't use HasChildren trait.

PublishedArticle will have problems with its polymorphic relationships (such as `internalComments()`. As the HasParent trait define getMorphClass() this way

```php
    public function getMorphClass()
    {
        if ($this->parentHasHasChildrenTrait()) {
            $parentClass = $this->getParentClass();
            return (new $parentClass)->getMorphClass();
        }

        return parent::getMorphClass();
    }
```

parent::getMorphClass() will return something like `App\PublishedArticle`and that wouldn't fetch anything since the entries in internal_comments table will likely be storing the model_type as 'articles' or `App\Article`

There isn't also a need for Article to use the HasChildren trait since it doesn't need to use the type column.

Hence to me it is better if the getMorphClass() in the HasParent trait to be done this way.

```php
    public function getMorphClass()
    {
            $parentClass = $this->getParentClass();

            return (new $parentClass)->getMorphClass();
    }
```

This way PublishedArticle getMorphClass() will always return `articles` or `App\Article` (Or wherever your folder structure to the Article model class is)

I can't think of a single table inheritance situation where say the internal_comments table will want to store `published_articles` in the model_type column. Instead of `articles`