### PR TITLE
Laravel 7 Support as well as match backwards compatible dev packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,12 +9,12 @@
         }
     ],
     "require": {
-        "illuminate/database": "~5.6.0|~5.7.0|~5.8.0|^6.0.0",
-        "illuminate/events": "~5.6.0|~5.7.0|~5.8.0|^6.0.0"
+        "illuminate/database": "~5.6.0|~5.7.0|~5.8.0|^6.0.0|^7.0.0",
+        "illuminate/events": "~5.6.0|~5.7.0|~5.8.0|^6.0.0|^7.0.0"
     },
     "require-dev": {
-        "orchestra/testbench": "3.8.*",
-        "phpunit/phpunit": "^7.0"
+        "orchestra/testbench": "~3.6.0|~3.7.0|~3.8.0|^4.0|^5.0",
+        "phpunit/phpunit": "^7.0|^8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Add Laravel 7 support and fill in backwards compatible versions of orchestra/testbench.