### PR TITLE
Named function scope in HasParent::bootHasParent().

### DIFF
--- a/src/HasParent.php
+++ b/src/HasParent.php
@@ -25,7 +25,7 @@ trait HasParent
             }
         });
 
-        static::addGlobalScope(function ($query) {
+        static::addGlobalScope('ParentalInheritance', function ($query) {
             $instance = new static;
 
             if ($instance->parentHasHasChildrenTrait()) {


### PR DESCRIPTION
Context: I was using Parental along with the NestedSets package (https://github.com/lazychaser/laravel-nestedset) when I found out that NestedSets indiscriminately used (in methods like parent(), siblings(), etc) the anonymous function scope that is being applied in bootHasParent(). This resulted in many errors with NestedSets.
So I resolved my problems by making NestedSets ignore the anonymous scope in bootHasParent. For this, the function scope needs a name.

(Regardless of my particular problem when using Parental with NestedSets, it's good to have that name anyway).