### PR TITLE
Get model instance from builder instead of creating a new instance

### DIFF
--- a/src/HasParent.php
+++ b/src/HasParent.php
@@ -26,7 +26,7 @@ trait HasParent
         });
 
         static::addGlobalScope(function ($query) {
-            $instance = new static;
+            $instance = $query->getModel();
 
             if ($instance->parentHasHasChildrenTrait()) {
                 $query->where($instance->getTable().'.'.$instance->getInheritanceColumn(), $instance->classToAlias(get_class($instance)));


### PR DESCRIPTION
This PR. fixes alias table name issue when use `has` method with another related child model:

```php
$sql = ChildModel::has('parent')->toSql();

// Output

// Before: select * from "parent_models" where exists (select * from "parent_models" as "laravel_reserved_0" where "laravel_reserved_0"."id" = "parent_models"."parent_model_id" and "parent_models"."type" = ?) and "parent_models"."type" = ?

// After:  select * from "parent_models" where exists (select * from "parent_models" as "laravel_reserved_0" where "laravel_reserved_0"."id" = "parent_models"."parent_model_id" and "laravel_reserved_0"."type" = ?) and "parent_models"."type" = ?
```