### PR TITLE
Allow use of Enum cast on inheritance column

### DIFF
--- a/src/HasChildren.php
+++ b/src/HasChildren.php
@@ -58,7 +58,7 @@ trait HasChildren
      */
     public function newInstance($attributes = [], $exists = false)
     {
-        $model = isset($attributes[$this->getInheritanceColumn()])
+        $model = isset($attributes[$this->getInheritanceColumn()]) && 
             ? $this->getChildModel($attributes)
             : new static(((array) $attributes));
 
@@ -181,10 +181,10 @@ trait HasChildren
     protected function getChildModel(array $attributes)
     {
         $className = $this->classFromAlias(
-            $attributes[$this->getInheritanceColumn()]
+            $attributes[$this->getInheritanceColumn()]->value ?? $attributes[$this->getInheritanceColumn()]
         );
 
-        return new $className((array)$attributes);
+        return $className === self::class ? new static(((array) $attributes)) : new $className((array)$attributes);
     }
 
     /**

--- a/src/HasChildren.php
+++ b/src/HasChildren.php
@@ -58,7 +58,7 @@ trait HasChildren
      */
     public function newInstance($attributes = [], $exists = false)
     {
-        $model = isset($attributes[$this->getInheritanceColumn()]) && 
+        $model = isset($attributes[$this->getInheritanceColumn()])
             ? $this->getChildModel($attributes)
             : new static(((array) $attributes));
 

--- a/src/HasChildren.php
+++ b/src/HasChildren.php
@@ -184,7 +184,7 @@ trait HasChildren
             $attributes[$this->getInheritanceColumn()]->value ?? $attributes[$this->getInheritanceColumn()]
         );
 
-        return $className === self::class ? new static(((array) $attributes)) : new $className((array)$attributes);
+        return new $className((array)$attributes);
     }
 
     /**


### PR DESCRIPTION
This change allows the type column to be cast to an enum, and for that enum to be mapped to a child type, I.e:

```php
class User 
{
use \Parental\HasChildren;

    protected $childTypes = [
        'admin' => Admin::class,
        'user' => User::class,
    ];
    
    protected $casts = [
        'type' => UserTypeEnum::class,
    ];
}
...
/**
 * @method static self admin()
 * @method static self user()
 */
class UserTypeEnum extends Enum
{
}

```
Or in php 8.1:
```php
enum UserTypeEnum
{
    case USER = 'user';
    case ADMIN = 'admin';
}
```