### PR TITLE
Added a nova package for parental to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -147,6 +147,7 @@ class NovaServiceProvider extends NovaApplicationServiceProvider
     }
 }
 ```
+Also, to quickly add children type fields in Nova, you can use [Nova Parental Field](https://github.com/wamadev/nova-parental-field)
 
 ---
 


### PR DESCRIPTION
This package basically populates the children types on a select field automatically. 
Thought it might be useful to have it referenced in the readme.