### PR TITLE
Give a name to the child's global scope

### DIFF
--- a/src/HasParent.php
+++ b/src/HasParent.php
@@ -25,7 +25,7 @@ trait HasParent
             }
         });
 
-        static::addGlobalScope(function ($query) {
+        static::addGlobalScope('singleTableInheritanceFilter', function ($query) {
             $instance = new static;
 
             if ($instance->parentHasHasChildrenTrait()) {


### PR DESCRIPTION
Currently, an anonymous global scope is registered in the HasParent trait, which adds a where clause to select only the rows which have the correct `childType`.

However, in certain cases one might want to disable this particular global scope, so it'd be nice if this scope is named (like  `singleTableInheritanceFilter` as I suggest in this PR).