### PR TITLE
Allow child types to be set via a method.

### DIFF
--- a/src/HasChildren.php
+++ b/src/HasChildren.php
@@ -14,11 +14,13 @@ trait HasChildren
     {
         parent::registerModelEvent($event, $callback);
 
-        if (static::class === self::class && property_exists(self::class, 'childTypes')) {
+        $childTypes = (new self)->getChildTypes();
+
+        if (static::class === self::class && $childTypes !== []) {
             // We don't want to register the callbacks that happen in the boot method of the parent, as they'll be called
             // from the child's boot method as well.
             if (! self::parentIsBooting()) {
-                foreach ((new self)->childTypes as $childClass) {
+                foreach ($childTypes as $childClass) {
                     if ($childClass !== self::class) {
                         $childClass::registerModelEvent($event, $callback);
                     }
@@ -193,10 +195,10 @@ trait HasChildren
      */
     public function classFromAlias($aliasOrClass)
     {
-        if (property_exists($this, 'childTypes')) {
-            if (isset($this->childTypes[$aliasOrClass])) {
-                return $this->childTypes[$aliasOrClass];
-            }
+        $childTypes = $this->getChildTypes();
+
+        if (isset($childTypes[$aliasOrClass])) {
+            return $childTypes[$aliasOrClass];
         }
 
         return $aliasOrClass;
@@ -208,10 +210,10 @@ trait HasChildren
      */
     public function classToAlias($className)
     {
-        if (property_exists($this, 'childTypes')) {
-            if (in_array($className, $this->childTypes)) {
-                return array_search($className, $this->childTypes);
-            }
+        $childTypes = $this->getChildTypes();
+
+        if (in_array($className, $childTypes)) {
+            return array_search($className, $childTypes);
         }
 
         return $className;

--- a/tests/Unit/HasChildrenTest.php
+++ b/tests/Unit/HasChildrenTest.php
@@ -18,6 +18,17 @@ class HasChildrenTest extends TestCase
 
         $this->assertEquals($model->mutatorWasCalled, false);
     }
+
+    /** @test */
+    function child_model_types_can_be_set_via_method()
+    {
+        $types = (new HasChildrenParentModelWithMethodTypes)->getChildTypes();
+
+        $this->assertEquals([
+            'foo' => Foo::class,
+            'bar' => Bar::class,
+        ], $types);
+    }
 }
 
 class HasChildrenParentModel extends Model {
@@ -32,5 +43,18 @@ class HasChildrenChildModel extends HasChildrenParentModel {
     public function setTestAttribute()
     {
         $this->mutatorWasCalled = true;
+    }
+}
+
+class HasChildrenParentModelWithMethodTypes extends Model
+{
+    use HasChildren;
+
+    public function getChildTypes()
+    {
+        return [
+            'foo' => Foo::class,
+            'bar' => Bar::class,
+        ];
     }
 }


### PR DESCRIPTION
Similar to #53, this allows the child types to be set via the `getChildTypes` method.

In our application's use case, once again similar to #53, we use an enum to map the `type` to the model's class. We have a `getClassMap()` static method on our enum which would reduce the amount of duplicate code if we were able to do this. 