### PR TITLE
Prepare for Laravel 9

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,9 @@ jobs:
             testbench: 6.*
           - laravel: 9.*
             testbench: 7.*
+        exclude:
+          - laravel: 9.*
+            php: 7.4
 
     name: PHP ${{ matrix.php }} - LARAVEL ${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: true
       matrix:
         php: [7.4, 8.0, 8.1]
-        laravel: [8.*, 9.*]
+        laravel: [8.*, 9.0]
         dependency-version: [prefer-stable]
         include:
           - laravel: 8.*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,15 +10,15 @@ jobs:
       fail-fast: true
       matrix:
         php: [7.4, 8.0, 8.1]
-        laravel: [8.*, 9.0]
+        laravel: [8.*, 9.*]
         dependency-version: [prefer-stable]
         include:
           - laravel: 8.*
             testbench: 6.*
           - laravel: 9.*
-            testbench: 7.x-dev
+            testbench: 7.*
         exclude:
-          - laravel: 9.0
+          - laravel: 9.*
             php: 7.4
 
     name: PHP ${{ matrix.php }} - LARAVEL ${{ matrix.laravel }} - ${{ matrix.dependency-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,12 +9,14 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.4, 8.0]
-        laravel: [8.*]
+        php: [7.4, 8.0, 8.1]
+        laravel: [8.*, 9.*]
         dependency-version: [prefer-stable]
         include:
           - laravel: 8.*
             testbench: 6.*
+          - laravel: 9.*
+            testbench: 7.*
 
     name: PHP ${{ matrix.php }} - LARAVEL ${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,9 +16,9 @@ jobs:
           - laravel: 8.*
             testbench: 6.*
           - laravel: 9.*
-            testbench: 7.*
+            testbench: 7.x-dev
         exclude:
-          - laravel: 9.*
+          - laravel: 9.0
             php: 7.4
 
     name: PHP ${{ matrix.php }} - LARAVEL ${{ matrix.laravel }} - ${{ matrix.dependency-version }}

--- a/composer.json
+++ b/composer.json
@@ -27,5 +27,7 @@
             "Parental\\Tests\\": "tests/",
             "Database\\Factories\\": "tests/factories/"
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,12 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "illuminate/database": "^8.0",
-        "illuminate/events": "^8.0"
+        "illuminate/database": "^8.0|^9.0",
+        "illuminate/events": "^8.0|9.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^6.0",
-        "phpunit/phpunit": "^8.5"
+        "orchestra/testbench": "^6.0|^7.0",
+        "phpunit/phpunit": "^8.5|^9.5.10"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": "^7.4|^8.0",
         "illuminate/database": "^8.0|^9.0",
-        "illuminate/events": "^8.0|9.0"
+        "illuminate/events": "^8.0|^9.0"
     },
     "require-dev": {
         "orchestra/testbench": "^6.0|^7.0",


### PR DESCRIPTION
This prepares the package to be installed together with Laravel 9.

Added:
- Dependencies for Laravel 9
- Tests for Laravel 9 on PHP 8.0 and PHP 8.1
- Tests for Laravel 8 on PHP 8.1