### PR TITLE
Allow a model to be both a parent and child

### DIFF
--- a/src/HasChildren.php
+++ b/src/HasChildren.php
@@ -138,7 +138,7 @@ trait HasChildren
         $instance = $this->newRelatedInstance($related);
 
         if (is_null($foreignKey) && $instance->hasParent) {
-            $foreignKey = Str::snake($instance->getClassNameForRelationships()).'_'.$instance->getKeyName();
+            $foreignKey = Str::snake($instance->getClassNameForHasChildrenRelationships()).'_'.$instance->getKeyName();
         }
 
         if (is_null($relation)) {
@@ -184,7 +184,7 @@ trait HasChildren
         $instance = $this->newRelatedInstance($related);
 
         if (is_null($table) && $instance->hasParent) {
-            $table = $this->joiningTable($instance->getClassNameForRelationships());
+            $table = $this->joiningTable($instance->getClassNameForHasChildrenRelationships());
         }
 
         return parent::belongsToMany(
@@ -201,7 +201,7 @@ trait HasChildren
     /**
      * @return string
      */
-    public function getClassNameForRelationships(): string
+    public function getClassNameForHasChildrenRelationships(): string
     {
         return class_basename($this);
     }

--- a/src/HasParent.php
+++ b/src/HasParent.php
@@ -81,13 +81,13 @@ trait HasParent
      */
     public function joiningTable($related, $instance = null): string
     {
-        $relatedClassName = method_exists((new $related), 'getClassNameForRelationships')
-            ? (new $related)->getClassNameForRelationships()
+        $relatedClassName = method_exists((new $related), 'getClassNameForHasParentRelationships')
+            ? (new $related)->getClassNameForHasParentRelationships()
             : class_basename($related);
 
         $models = [
             Str::snake($relatedClassName),
-            Str::snake($this->getClassNameForRelationships()),
+            Str::snake($this->getClassNameForHasParentRelationships()),
         ];
 
         sort($models);
@@ -99,7 +99,7 @@ trait HasParent
      * @return string
      * @throws ReflectionException
      */
-    public function getClassNameForRelationships(): string
+    public function getClassNameForHasParentRelationships(): string
     {
         return class_basename($this->getParentClass());
     }


### PR DESCRIPTION
The only reason this didn't work previously was due to duplicate method names in HasParent and HasChildren traits.

We have a use case where we have several layers of abstraction:

A extends B
B extends C

With this change we can now:

A HasParent
B HasParent, Has Children
C Has Children

and by C::find('1234') will return the class instance of A correctly. 