### PR TITLE
Put a flag on what morph class to return from a child

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.1, 8.2, 8.3]
+        php: [8.1, 8.2, 8.3, 8.4]
         laravel: ["10.*", "11.*", "12.*"]
         dependency-version: [prefer-stable]
         include:

--- a/src/HasParent.php
+++ b/src/HasParent.php
@@ -104,6 +104,10 @@ trait HasParent
      */
     public function getMorphClass(): string
     {
+        if ($this->returnsChildMorphClass ?? false) {
+            return parent::getMorphClass();
+        }
+
         $parentClass = $this->getParentClass();
 
         return (new $parentClass)->getMorphClass();

--- a/tests/Unit/HasParent/ChildModelWithOwnMorphClass.php
+++ b/tests/Unit/HasParent/ChildModelWithOwnMorphClass.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Parental\Tests\Unit\HasParent;
+
+use Parental\HasParent;
+
+class ChildModelWithOwnMorphClass extends ParentModel
+{
+    use HasParent;
+
+    protected bool $returnsChildMorphClass = true;
+}

--- a/tests/Unit/HasParentTest.php
+++ b/tests/Unit/HasParentTest.php
@@ -5,8 +5,11 @@ namespace Parental\Tests\Unit;
 use Parental\Tests\TestCase;
 use Parental\Tests\Unit\HasParent\ChildModel;
 use Parental\Tests\Unit\HasParent\ChildModelWithoutTrait;
+use Parental\Tests\Unit\HasParent\ChildModelWithOwnMorphClass;
 use Parental\Tests\Unit\HasParent\ParentModel;
 use Parental\Tests\Unit\HasParent\RelatedModel;
+use ReflectionClass;
+use TypeError;
 
 class HasParentTest extends TestCase
 {
@@ -34,5 +37,60 @@ class HasParentTest extends TestCase
         $this->assertEquals('parent_model_related_model', (new ParentModel)->joiningTable($related));
         $this->assertEquals('parent_model_related_model', (new ChildModel)->joiningTable($related));
         $this->assertEquals('child_model_without_trait_related_model', (new ChildModelWithoutTrait)->joiningTable($related));
+    }
+
+    /** @test */
+    public function child_model_returns_parent_morph_class_by_default()
+    {
+        $this->assertEquals(ParentModel::class, (new ChildModel)->getMorphClass());
+    }
+
+    /** @test */
+    public function child_model_with_parent_morph_class_causes_lazy_proxy_error()
+    {
+        if (PHP_VERSION_ID < 80400) {
+            $this->markTestSkipped('ReflectionClass::newLazyProxy requires PHP 8.4+');
+        }
+
+        $child = new ChildModel;
+        $morphClass = $child->getMorphClass();
+
+        // The morph class returns the parent class
+        $this->assertEquals(ParentModel::class, $morphClass);
+
+        // Creating a lazy proxy using the morph class but returning a child instance causes TypeError
+        $reflector = new ReflectionClass($morphClass);
+        $proxy = $reflector->newLazyProxy(function ($proxy) {
+            return new ChildModel;
+        });
+
+        $this->expectException(TypeError::class);
+        $this->expectExceptionMessage('The real instance class');
+
+        // Accessing a property triggers the lazy initialization and causes the error
+        $proxy->getTable();
+    }
+
+    /** @test */
+    public function child_model_with_own_morph_class_works_with_lazy_proxy()
+    {
+        if (PHP_VERSION_ID < 80400) {
+            $this->markTestSkipped('ReflectionClass::newLazyProxy requires PHP 8.4+');
+        }
+
+        $child = new ChildModelWithOwnMorphClass;
+        $morphClass = $child->getMorphClass();
+
+        // The morph class returns the child class when returnsChildMorphClass is true
+        $this->assertEquals(ChildModelWithOwnMorphClass::class, $morphClass);
+
+        // Creating a lazy proxy using the morph class works correctly
+        $reflector = new ReflectionClass($morphClass);
+        $proxy = $reflector->newLazyProxy(function ($proxy) {
+            return new ChildModelWithOwnMorphClass;
+        });
+
+        // Accessing a property works without error
+        $this->assertEquals(ChildModelWithOwnMorphClass::class, $proxy->getMorphClass());
     }
 }


### PR DESCRIPTION
#33 updated the getMorphClass method to return the parent's morph class. Livewire supports using ReflectionClass::newLazyProxy if running on PHP 8.4+. This causes issues when the ReflectionClass instance is created using the parent class, but the callback function returns the child. So for my use case, I needed to return the parent::getMorphClass value from the child, not the parent classes getMorphClass value.

This change adds a simple boolean flag/property that can be added to child classes to use parent::getMorphClass. Also maintains backwards compatibility with what #33 implemented to not break anyone. Test cases to replicate included as well.